### PR TITLE
Ability to use post expirator again

### DIFF
--- a/wpuf-add-post.php
+++ b/wpuf-add-post.php
@@ -472,6 +472,7 @@ class WPUF_Add_Post {
                 $expiration = $post_date + ($expiration * 60 * 60 * 24);
 
                 add_post_meta( $post_id, 'expiration-date', $expiration, true );
+                _scheduleExpiratorEvent($post_id,$expiration,$opts);
             }
 
             //plugin API to extend the functionality


### PR DESCRIPTION
I added some code I found in the web in l. 475 of "wpuf-add-post.php" (see http://wordpress.org/support/topic/posts-dont-expire). Don't know why it's not already changed, but with this the post expiration function now works for me again.